### PR TITLE
Add DeviceGroup.

### DIFF
--- a/granadilla/cli.py
+++ b/granadilla/cli.py
@@ -235,7 +235,6 @@ class CLI(object):
                 acl.name = groupname
                 acl.members = [ user.dn ]
                 acl.save()
-        self.sync_device_acls()
 
     @command
     def catgroup(self, groupname):
@@ -276,6 +275,7 @@ class CLI(object):
                 models.LdapAcl.objects.get(name=groupname).delete()
             except models.LdapAcl.DoesNotExist:
                 pass
+        self.sync_device_acls()
 
     @command
     def delusergroup(self, username, groupname):
@@ -284,7 +284,6 @@ class CLI(object):
         group = models.LdapGroup.objects.get(name=groupname)
 
         self._delusergroup(user, group)
-        self.sync_device_acls()
 
     def _delusergroup(self, user, group):
         if user.username in group.usernames:
@@ -315,7 +314,6 @@ class CLI(object):
 
         self.warn("Removing user %s", user.dn)
         user.delete()
-        self.sync_device_acls()
 
     @command
     def init(self):

--- a/granadilla/cli_settings.py
+++ b/granadilla/cli_settings.py
@@ -126,6 +126,8 @@ GRANADILLA_EXTERNAL_USERS_DN = '%s,%s' % (GRANADILLA_EXTERNAL_USERS_OU, GRANADIL
 # The organizationalUnit for devices
 GRANADILLA_DEVICES_OU = config.get('granadilla.devices', 'ou=devices')
 GRANADILLA_DEVICES_DN = '%s,%s' % (GRANADILLA_DEVICES_OU, GRANADILLA_BASE_DN)
+GRANADILLA_DEVICEGROUPS_DN = GRANADILLA_DEVICES_DN
+
 # The organizationalUnit for services
 GRANADILLA_SERVICES_OU = config.get('granadilla.services_ou', 'ou=services')
 GRANADILLA_SERVICES_DN = '%s,%s' % (GRANADILLA_SERVICES_OU, GRANADILLA_BASE_DN)

--- a/granadilla/conf.py
+++ b/granadilla/conf.py
@@ -43,6 +43,8 @@ class GranadillaConf(appconf.AppConf):
     GROUPS_DN = 'ou=groups,dc=example,dc=org'
     SERVICES_DN = 'ou=services,dc=example,dc=org'
     USERS_DN = 'ou=users,dc=example,dc=org'
+    DEVICES_DN = 'ou=devices,dc=example,dc=org'
+    DEVICEGROUPS_DN = DEVICES_DN
     USE_ACLS = False
 
     # Homepage: "full company" group name

--- a/granadilla/models.py
+++ b/granadilla/models.py
@@ -108,6 +108,18 @@ class LdapGroup(ldap_models.Model):
     def get_members(self):
         return LdapUser.objects.get(username__in=self.usernames)
 
+    def save(self, *args, **kwargs):
+        res = super(LdapGroup, self).save(*args, **kwargs)
+
+        try:
+            device_group = LdapDeviceGroup.objects.get(group_dn=self.dn)
+        except LdapDeviceGroup.DoesNotExist:
+            pass
+        else:
+            device_group.resync()
+
+        return res
+
 
 class LdapServiceAccount(ldap_models.Model):
     """Class for a Service account."""

--- a/granadilla_webapp/settings.py
+++ b/granadilla_webapp/settings.py
@@ -127,6 +127,8 @@ GRANADILLA_EXTERNAL_USERS_DN = '%s,%s' % (GRANADILLA_EXTERNAL_USERS_OU, GRANADIL
 # The organizationalUnit for devices
 GRANADILLA_DEVICES_OU = config.get('granadilla.devices_ou', 'ou=external_users')
 GRANADILLA_DEVICES_DN = '%s,%s' % (GRANADILLA_DEVICES_OU, GRANADILLA_BASE_DN)
+GRANADILLA_DEVICEGROUPS_DN = GRANADILLA_DEVICES_DN
+
 # The organizationalUnit for services
 GRANADILLA_SERVICES_OU = config.get('granadilla.services_ou', 'ou=services')
 GRANADILLA_SERVICES_DN = '%s,%s' % (GRANADILLA_SERVICES_OU, GRANADILLA_BASE_DN)


### PR DESCRIPTION
In the ``devices`` ou, these are a shortcut to fetch "all devices
whose owner belongs to the given group".

They are useful for restricting device access based on owner group
membership, and allow to keep those memberships up to date.