### PR TITLE
Be more specific on which settings file to include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,4 @@ graft granadilla_webapp
 
 global-exclude *.py[cod] __pycache__ *.swp *.mo
 
-include *_settings.ini granadilla-admin Makefile manage.py tox.ini .flake8 .travis.yml
+include example_settings.ini test_settings.ini granadilla-admin Makefile manage.py tox.ini .flake8 .travis.yml


### PR DESCRIPTION
Est-ce que c'est normal que le MANIFEST.in spécifie : `include *_settings.ini`.

Est-ce qu'on ne veut pas plutôt être spécifique sur ceux à inclure et les nommer ?

```
include example_settings.ini
include test_settings.ini
```

En effet si on se pose la question on ne veut pas tous les inclure mais seulement quelques uns très spécifiques.